### PR TITLE
Refactor inference-notify for compliance and LDN adherence

### DIFF
--- a/inference-notify-demo/inbox_server.py
+++ b/inference-notify-demo/inbox_server.py
@@ -4,11 +4,13 @@
 # ///
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 import json, time
 
 app = FastAPI(title="LDN Inbox (POC)")
 INBOX = Path("state/inbox"); INBOX.mkdir(parents=True, exist_ok=True)
+app.mount("/state", StaticFiles(directory="state"), name="state")
 
 @app.post("/inbox")
 async def inbox_post(req: Request):

--- a/inference-notify-demo/poll_and_run.py
+++ b/inference-notify-demo/poll_and_run.py
@@ -37,6 +37,8 @@ def get_message_id(message: dict) -> str:
 # --- Notification Helpers ---
 def post_announce(object_name, file_path, generating_activity):
     """Posts an 'Announce' notification to the inbox about a generated resource."""
+    base_url = INBOX_URL.rsplit('/', 1)[0]
+    object_url = f"{base_url}/{STATE_DIR}/{object_name}"
     payload = {
         "@context": ["https://www.w3.org/ns/activitystreams", "https://www.w3.org/ns/prov#"],
         "type": "Announce",
@@ -45,7 +47,7 @@ def post_announce(object_name, file_path, generating_activity):
             "type": "Document",
             "id": f"urn:smartbibl:state:{object_name}",
             "name": object_name,
-            "url": f"file://{os.path.abspath(file_path)}"
+            "url": object_url
         },
         "prov:wasGeneratedBy": generating_activity
     }
@@ -67,7 +69,7 @@ def run_command(command):
 
 def build_inference_command(params: dict) -> list[str]:
     """Builds the command to execute the inference script from notification parameters."""
-    cmd = ["uv", "run", "inference.py"]
+    cmd = ["uv", "run", "https://raw.githubusercontent.com/gegedenice/LLM-notify/main/inference-notify-demo/inference.py"]
     # Required parameters
     cmd.extend(["--provider", params["provider"]])
     cmd.extend(["--model", params["model"]])

--- a/inference-notify-demo/send_ldn.py
+++ b/inference-notify-demo/send_ldn.py
@@ -2,14 +2,72 @@
 # requires-python = ">=3.10"
 # dependencies = ["httpx>=0.27"]
 # ///
-import argparse, json, httpx, sys
-ap = argparse.ArgumentParser()
-ap.add_argument("--inbox", required=True)
-ap.add_argument("--payload", required=True, help="JSON file")
-a = ap.parse_args()
-response = httpx.get(a.payload)
-response.raise_for_status() # Raise an exception for bad status codes
-data = json.loads(response.text)
-r = httpx.post(a.inbox, headers={"Content-Type":"application/ld+json"}, json=data, timeout=30)
-r.raise_for_status()
-print("Sent:", r.json())
+import argparse
+import json
+import httpx
+import sys
+import uuid
+
+def main():
+    parser = argparse.ArgumentParser(description="Send an inference job to an LDN inbox.")
+    # Connection
+    parser.add_argument("--inbox", required=True, help="URL of the LDN inbox.")
+
+    # LLM parameters (mirroring inference.py)
+    parser.add_argument("--provider", required=True, help="LLM provider (e.g., 'groq', 'openai').")
+    parser.add_argument("--model", required=True, help="Model name to use for inference.")
+    parser.add_argument("--user-prompt", required=True, help="The prompt to send to the model.")
+    parser.add_argument("--system-prompt", help="Optional system prompt.")
+
+    # Extra options
+    parser.add_argument("--options-json", help='Arbitrary options as a JSON string, e.g., \'{"temperature":0.5}\'.')
+    parser.add_argument("--actor", default="https://example.org/users/cli-user", help="Actor URI for the notification.")
+
+    args = parser.parse_args()
+
+    # Build the 'object' part of the LDN message
+    job_object = {
+        "provider": args.provider,
+        "model": args.model,
+        "user_prompt": args.user_prompt,
+    }
+    if args.system_prompt:
+        job_object["system_prompt"] = args.system_prompt
+    if args.options_json:
+        try:
+            job_object["options"] = json.loads(args.options_json)
+        except json.JSONDecodeError:
+            print(f"Error: Invalid JSON in --options-json: {args.options_json}", file=sys.stderr)
+            return 1
+
+    # Build the full LDN notification payload
+    payload = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "type": "Create",
+        "actor": args.actor,
+        "object": job_object,
+        "instrument": {
+            "type": "Service",
+            "action": "infer"
+        }
+    }
+
+    print(f"Sending payload to {args.inbox}:")
+    print(json.dumps(payload, indent=2))
+
+    try:
+        r = httpx.post(args.inbox, headers={"Content-Type": "application/ld+json"}, json=payload, timeout=30)
+        r.raise_for_status()
+        print("\nSent successfully. Response:", r.json())
+    except httpx.RequestError as e:
+        print(f"\nError sending notification: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"\nAn unexpected error occurred: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This commit refactors the `inference-notify-demo` project to improve its compliance with `inference.py`, ensure remote script execution, and enhance its adherence to the Linked Data Notifications (LDN) standard.

The following changes were made:

- `send_ldn.py`: The script has been updated to be a proper client for the inference service. It now accepts command-line arguments that mirror `inference.py` and dynamically constructs the LDN payload.
- `poll_and_run.py`: The script now uses the raw GitHub URL to run `inference.py`, ensuring that the system is not dependent on local file paths. The result notification has also been updated to use a public HTTP URL.
- `inbox_server.py`: The server now serves the `state` directory, allowing inference results to be accessed over HTTP, which is crucial for a distributed system.