### PR TITLE
Refactor inference-notify for compliance and LDN adherence

### DIFF
--- a/inference-notify-demo/README.md
+++ b/inference-notify-demo/README.md
@@ -2,19 +2,18 @@
 
 This demo showcases a distributed, notification-driven architecture for running LLM inference tasks. It uses a W3C Linked Data Notifications (LDN) inbox to receive jobs and an orchestrator to trigger an OpenAI-compatible inference client.
 
-This approach decouples the requestor from the inference service, allowing for asynchronous, auditable, and scalable AI workflows.
+This approach decouples the requestor from the inference service, allowing for a scalable, auditable, and asynchronous AI workflow. All scripts are designed to be run remotely via `uv`, requiring no local installation.
 
 ## Project Structure
 
 ```
 inference-notify-demo/
  ├─ README.md
- ├─ inbox_server.py         # Simple LDN inbox server
+ ├─ inbox_server.py         # Simple LDN inbox server, also serves results
  ├─ poll_and_run.py         # Orchestrator: polls inbox and runs inference
  ├─ inference.py            # Universal inference client (OpenAI, Groq, etc.)
- ├─ examples/
- │   └─ inference.job.json  # Sample notification payload to trigger a job
- └─ state/                  # Outputs from the demo (seen messages, results)
+ ├─ send_ldn.py             # Client to send an inference job notification
+ └─ state/                  # Outputs from the demo (inbox messages, results)
 ```
 
 ## How to Run
@@ -23,27 +22,29 @@ You will need three separate terminals to run the full demo.
 
 ### 1. Launch the Inbox Server (Terminal A)
 
-This server listens for incoming notifications.
+This server listens for incoming notifications and serves the resulting output files.
 
 ```bash
-uv run inbox_server.py
+uv run https://raw.githubusercontent.com/gegedenice/LLM-notify/main/inference-notify-demo/inbox_server.py
 ```
 
-It will start listening on `http://localhost:8080/inbox`.
+It will start listening on `http://localhost:8080`. The inbox is at `/inbox`.
 
 ### 2. Send an Inference Job Notification (Terminal B)
 
-This command sends the job defined in `examples/inference.job.json` to the inbox. You can customize the `inference.job.json` file to change the provider, model, prompt, or other parameters.
+This command constructs and sends a job notification to the inbox.
 
 ```bash
-uv run send_ldn.py \
+uv run https://raw.githubusercontent.com/gegedenice/LLM-notify/main/inference-notify-demo/send_ldn.py \
   --inbox http://localhost:8080/inbox \
-  --payload examples/inference.job.json
+  --provider "groq" \
+  --model "llama3-8b-8192" \
+  --user-prompt "Explain the importance of the W3C Linked Data Notifications standard in 3 sentences."
 ```
 
 ### 3. Launch the Orchestrator (Terminal C)
 
-The orchestrator polls the inbox, finds the new job, and executes the `inference.py` script with the parameters from the notification.
+The orchestrator polls the inbox, finds the new job, and executes the remote `inference.py` script with the parameters from the notification.
 
 **Before running, ensure you have set the required API key for your chosen provider (e.g., `GROQ_API_KEY`).**
 
@@ -53,7 +54,16 @@ export GROQ_API_KEY="YOUR_API_KEY_HERE"
 
 # Launch the orchestrator
 INBOX_URL=http://localhost:8080/inbox \
-uv run poll_and_run.py
+uv run https://raw.githubusercontent.com/gegedenice/LLM-notify/main/inference-notify-demo/poll_and_run.py
 ```
 
-The orchestrator will detect the notification and run the inference. The result will be printed to the console and saved as a `.txt` file in the `state/` directory. A final "Announce" notification will be sent to the inbox, confirming the completion of the task.
+The orchestrator will detect the notification and run the inference. The result will be saved as a `.txt` file in the `state/` directory, and a final "Announce" notification will be sent to the inbox, confirming the completion of the task. You can view the result at a URL like `http://localhost:8080/state/inference-result-....txt`.
+
+### Production Note: Versioning
+
+For production or stable environments, it is recommended to replace `main` in the script URLs with a specific commit SHA. This ensures that you are running a fixed, tested version of the code.
+
+Example:
+```
+https://raw.githubusercontent.com/gegedenice/LLM-notify/a1b2c3d4/inference-notify-demo/inbox_server.py
+```


### PR DESCRIPTION
This commit refactors the `inference-notify-demo` project to improve its compliance with `inference.py`, ensure remote script execution, enhance its adherence to the Linked Data Notifications (LDN) standard, and update documentation.

The following changes were made:

- `send_ldn.py`: The script has been updated to be a proper client for the inference service. It now accepts command-line arguments that mirror `inference.py` and dynamically constructs the LDN payload.
- `poll_and_run.py`: The script now uses the raw GitHub URL to run `inference.py`, ensuring that the system is not dependent on local file paths. The result notification has also been updated to use a public HTTP URL.
- `inbox_server.py`: The server now serves the `state` directory, allowing inference results to be accessed over HTTP, which is crucial for a distributed system.
- `README.md`: The documentation has been updated to reflect the new remote script URLs and the updated usage of `send_ldn.py`. It also includes a new section on versioning for production environments.