### PR TITLE
feat: Implement full argument parity for inference jobs

### DIFF
--- a/inference-notify-demo/poll_and_run.py
+++ b/inference-notify-demo/poll_and_run.py
@@ -68,20 +68,24 @@ def run_command(command):
     return process.stdout
 
 def build_inference_command(params: dict) -> list[str]:
-    """Builds the command to execute the inference script from notification parameters."""
+    """
+    Builds the command to execute the remote inference script from detailed
+    notification parameters.
+    """
+    # Base command using the remote script URL
     cmd = ["uv", "run", "https://raw.githubusercontent.com/gegedenice/LLM-notify/main/inference-notify-demo/inference.py"]
-    # Required parameters
-    cmd.extend(["--provider", params["provider"]])
-    cmd.extend(["--model", params["model"]])
-    cmd.extend(["--user-prompt", params["user_prompt"]])
 
-    # Optional parameters
-    if "system_prompt" in params:
-        cmd.extend(["--system-prompt", params["system_prompt"]])
+    # Dynamically map all keys from the notification to command-line flags
+    for key, value in params.items():
+        flag = f"--{key.replace('_', '-')}"
 
-    # Pass other options via JSON
-    if "options" in params and isinstance(params["options"], dict):
-        cmd.extend(["--options-json", json.dumps(params["options"])])
+        # For boolean flags (like --list-models), just add the flag if True
+        if isinstance(value, bool) and value:
+            cmd.append(flag)
+        # For all other types, add the flag and its value
+        elif not isinstance(value, bool):
+            cmd.append(flag)
+            cmd.append(str(value))
 
     return cmd
 

--- a/inference-notify-demo/send_ldn.py
+++ b/inference-notify-demo/send_ldn.py
@@ -9,36 +9,52 @@ import sys
 import uuid
 
 def main():
-    parser = argparse.ArgumentParser(description="Send an inference job to an LDN inbox.")
-    # Connection
+    parser = argparse.ArgumentParser(
+        description="Send a detailed inference job to an LDN inbox, mirroring all of inference.py's arguments."
+    )
+    # --- Arguments for send_ldn.py
     parser.add_argument("--inbox", required=True, help="URL of the LDN inbox.")
-
-    # LLM parameters (mirroring inference.py)
-    parser.add_argument("--provider", required=True, help="LLM provider (e.g., 'groq', 'openai').")
-    parser.add_argument("--model", required=True, help="Model name to use for inference.")
-    parser.add_argument("--user-prompt", required=True, help="The prompt to send to the model.")
-    parser.add_argument("--system-prompt", help="Optional system prompt.")
-
-    # Extra options
-    parser.add_argument("--options-json", help='Arbitrary options as a JSON string, e.g., \'{"temperature":0.5}\'.')
     parser.add_argument("--actor", default="https://example.org/users/cli-user", help="Actor URI for the notification.")
+
+    # --- Arguments mirrored from inference.py
+    # Core
+    parser.add_argument("--provider", required=True, help="openai | groq | ollama | hf|huggingface")
+    parser.add_argument("--model", required=True, help="Model name to use for inference.")
+    parser.add_argument("--base-url", help="Override base URL for the provider.")
+
+    # Provider-specific
+    parser.add_argument("--hf-subpath", help="HuggingFace router subpath (default: openai/v1)")
+
+    # Operations
+    parser.add_argument("--list-models", action="store_true", help="List available models (note: this is a client-side flag).")
+    parser.add_argument("--json-output", action="store_true", help="Request raw JSON output from inference.")
+    parser.add_argument("--verbose", action="store_true", help="Request verbose logs from inference.")
+
+    # Prompts
+    parser.add_argument("-u", "--user-prompt", required=True, help="User prompt text.")
+    parser.add_argument("-s", "--system-prompt", help="System prompt text.")
+
+    # Common completion options
+    parser.add_argument("--temperature", type=float, help="Sampling temperature.")
+    parser.add_argument("--top-p", type=float, help="Top-p sampling.")
+    parser.add_argument("--max-tokens", type=int, help="Max tokens in response.")
+    parser.add_argument("--stream", type=lambda v: str(v).lower() in {"1", "true", "yes"}, help="Enable streaming (bool).")
+
+    # Reasoning effort
+    parser.add_argument("--reasoning-effort", choices=["low", "medium", "high"], help="Request extra reasoning effort.")
 
     args = parser.parse_args()
 
-    # Build the 'object' part of the LDN message
-    job_object = {
-        "provider": args.provider,
-        "model": args.model,
-        "user_prompt": args.user_prompt,
-    }
-    if args.system_prompt:
-        job_object["system_prompt"] = args.system_prompt
-    if args.options_json:
-        try:
-            job_object["options"] = json.loads(args.options_json)
-        except json.JSONDecodeError:
-            print(f"Error: Invalid JSON in --options-json: {args.options_json}", file=sys.stderr)
-            return 1
+    # Build the 'object' part of the LDN message from all provided args
+    job_object = {}
+    for arg, value in vars(args).items():
+        # Exclude args specific to the sending script and only include args that were actually provided
+        if arg not in ['inbox', 'actor'] and value is not None:
+            # Convert boolean flags to a more explicit representation if they are True
+            if isinstance(value, bool) and value:
+                job_object[arg] = True
+            elif not isinstance(value, bool):
+                job_object[arg] = value
 
     # Build the full LDN notification payload
     payload = {
@@ -53,18 +69,19 @@ def main():
         }
     }
 
-    print(f"Sending payload to {args.inbox}:")
+    print("--- Sending Notification ---")
     print(json.dumps(payload, indent=2))
+    print("--------------------------")
 
     try:
         r = httpx.post(args.inbox, headers={"Content-Type": "application/ld+json"}, json=payload, timeout=30)
         r.raise_for_status()
-        print("\nSent successfully. Response:", r.json())
+        print("\n=> Sent successfully. Inbox response:", r.json())
     except httpx.RequestError as e:
-        print(f"\nError sending notification: {e}", file=sys.stderr)
+        print(f"\n[ERROR] Failed to send notification: {e}", file=sys.stderr)
         return 1
     except Exception as e:
-        print(f"\nAn unexpected error occurred: {e}", file=sys.stderr)
+        print(f"\n[ERROR] An unexpected error occurred: {e}", file=sys.stderr)
         return 1
 
     return 0


### PR DESCRIPTION
This commit completes a comprehensive refactor of the `inference-notify-demo` project to ensure full argument parity between `send_ldn.py` and `inference.py`, providing complete auditability and reproducibility for inference jobs.

The key changes are:

1.  **send_ldn.py**: Rewritten to accept every command-line argument from `inference.py` (except `api-key`). It now constructs a detailed LDN notification where every parameter is a distinct key-value pair in the `object` field. This is critical for auditability.

2.  **poll_and_run.py**: The `build_inference_command` function has been replaced with a dynamic builder. It now iterates through all parameters in the received notification and constructs the `uv run` command with the correct flags, removing the previous reliance on `--options-json`.

3.  **README.md**: The documentation has been updated with new examples that showcase the detailed, granular control now available through `send_ldn.py`'s arguments.

4.  **inbox_server.py**: Serves the `state` directory to make inference results accessible over HTTP, completing the LDN-compliant workflow.

This new implementation fully aligns with the goal of a decoupled, auditable, and asynchronous inference system.