### PR TITLE
Generate documentation for paper illustration folders

### DIFF
--- a/RAG-notify-demo/README.md
+++ b/RAG-notify-demo/README.md
@@ -61,3 +61,207 @@ uv run https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/pol
 uv run https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/query.py --index state/index.jsonl \
   --q "De quoi parle le document ?" --k 5
 ```
+
+## English overview
+
+This folder is a minimal, working illustration of the ideas in the paper
+[Distributed AI over Normalized Notifications (LDN)](https://vixra.org/pdf/2510.0040v1.pdf).
+It demonstrates a distributed, notification-driven RAG pipeline where each
+processing step is a micro-service triggered by W3C Linked Data Notifications
+(LDN).
+
+- **Event-driven index**: a `Create` notification with `instrument.action = "index"`
+  tells the system a document changed and must be reprocessed.
+- **Streaming provenance**: each step posts an `Announce` message referencing
+  the generated artifact in `state/` and the activity that produced it.
+- **Interoperability**: notifications are JSON-LD (ActivityStreams + PROV), easy
+  to route, store, and audit across services.
+
+## Relation to the paper
+
+- **Create vs Announce**: The paper’s normalized event model is applied here:
+  `Create` carries the job request; each processing stage returns an `Announce`
+  that points to the freshly created artifact and includes provenance
+  (`prov:wasGeneratedBy`).
+- **Decoupling**: The inbox is a simple web endpoint; producers and consumers
+  only share schemas, not code or runtimes.
+
+## Prerequisites
+
+- Python 3.10+
+- [`uv`](https://docs.astral.sh/uv/) installed (used to run scripts and their
+  declared dependencies without a local venv)
+- Internet access on first run (to download Python deps and models)
+
+## End‑to‑end flow
+
+1) A `Create` LDN message is posted to the inbox with `instrument.action = index`
+   and an `object.url` (or `object.id`) pointing to the source document.
+2) The orchestrator polls the inbox and, for each unseen job, runs:
+   - `splitter.py` → writes `state/chunks.jsonl`
+   - `embedder.py` → writes `state/embeddings.jsonl`
+   - `indexer.py` → writes `state/index.jsonl`
+   After each step, it posts an `Announce` with a link to the produced file.
+3) You can then query the index with `query.py`.
+
+The `state/` directory is created in the current working directory the scripts
+run from. The inbox stores incoming messages under `state/inbox/`. A
+`state/seen.txt` file prevents reprocessing the same message.
+
+## Quickstart (local)
+
+You can use the local scripts in this folder with `uv run`.
+
+### 1) Start the inbox (Terminal A)
+
+```bash
+uv run RAG-notify-demo/inbox_server.py
+```
+
+It listens on `http://localhost:8080`. The inbox is at `/inbox`, and the
+`state/` directory is served at `/state`.
+
+### 2) Send a Create notification (Terminal B)
+
+Option A — use the helper sender with a hosted JSON payload:
+
+```bash
+uv run RAG-notify-demo/send_ldn.py \
+  --inbox http://localhost:8080/inbox \
+  --payload https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/examples/job.create.json
+```
+
+Option B — send directly with curl (inline JSON):
+
+```bash
+curl -sS -X POST \
+  -H "Content-Type: application/ld+json" \
+  --data '{
+    "@context": ["https://www.w3.org/ns/activitystreams"],
+    "type": "Create",
+    "actor": "https://smartbibl.ia/actors/publisher",
+    "object": {
+      "type": "Document",
+      "url": "https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/examples/Inist_RA2024.md",
+      "mediaType": "text/plain",
+      "name": "Sample Text"
+    },
+    "instrument": {"type": "Service", "name": "RAG Pipeline", "action": "index"}
+  }' \
+  http://localhost:8080/inbox
+```
+
+### 3) Orchestrate the pipeline (Terminal C)
+
+Option A — use a remote runner (recommended to pin to a commit for reproducibility):
+
+```bash
+# Replace `main` with a commit SHA in production
+INBOX_URL=http://localhost:8080/inbox \
+uv run https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/poll_and_run.py
+```
+
+Option B — run the steps manually (no orchestrator):
+
+```bash
+uv run RAG-notify-demo/splitter.py --in \
+  https://raw.githubusercontent.com/gegedenice/uv-scripts/main/RAG-demo/examples/Inist_RA2024.md \
+  --out state/chunks.jsonl --chunk-size 900
+
+uv run RAG-notify-demo/embedder.py --in state/chunks.jsonl \
+  --out state/embeddings.jsonl --model sentence-transformers/all-MiniLM-L6-v2
+
+uv run RAG-notify-demo/indexer.py --in state/embeddings.jsonl --out state/index.jsonl
+```
+
+### 4) Query the index
+
+```bash
+uv run RAG-notify-demo/query.py --index state/index.jsonl \
+  --q "What is the document about?" --k 5
+```
+
+## CLI reference (local scripts)
+
+- `splitter.py`
+  - `--in` (URL or `file://`), `--out` (file), `--chunk-size` (chars, default 900)
+- `embedder.py`
+  - `--in`, `--out`, `--model` (default `sentence-transformers/all-MiniLM-L6-v2`)
+- `indexer.py`
+  - `--in`, `--out`
+- `query.py`
+  - `--index`, `--q`, `--k` (default 5), `--model`
+- `send_ldn.py`
+  - `--inbox`, `--payload` (HTTP(S) URL to JSON)
+
+## Message formats
+
+Minimal `Create` request (triggers indexing):
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/activitystreams"],
+  "type": "Create",
+  "actor": "https://smartbibl.ia/actors/publisher",
+  "object": {
+    "type": "Document",
+    "url": "https://example.org/doc.txt",
+    "mediaType": "text/plain",
+    "name": "Doc Title"
+  },
+  "instrument": {"type": "Service", "name": "RAG Pipeline", "action": "index"}
+}
+```
+
+`Announce` message (emitted after each stage):
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://www.w3.org/ns/prov#"
+  ],
+  "type": "Announce",
+  "actor": "https://smartbibl.ia/actors/runner",
+  "object": {
+    "type": "Document",
+    "id": "urn:smartbibl:state:chunks",
+    "name": "chunks",
+    "url": "http://localhost:8080/state/chunks.jsonl"
+  },
+  "prov:wasGeneratedBy": {
+    "type": "Activity",
+    "prov:wasAssociatedWith": "splitter.py@<COMMIT>"
+  }
+}
+```
+
+## State directory layout
+
+```
+state/
+  inbox/                  # stored LDN messages (JSON)
+  seen.txt                # ids of processed messages
+  chunks.jsonl            # splitter output
+  embeddings.jsonl        # embedder output
+  index.jsonl             # indexer output
+```
+
+## Troubleshooting
+
+- If `sentence-transformers` downloads are slow, the first run may take time.
+- If you see HTTP errors from remote URLs, check connectivity and CORS.
+- If running the orchestrator remotely, prefer pinning to a specific commit SHA
+  rather than `main`.
+- Delete the `state/` directory to re-run from a clean slate.
+
+## Extending
+
+- Swap the embedding model via `--model` in `embedder.py`.
+- Change chunking via `--chunk-size` in `splitter.py`.
+- Replace `indexer.py` with a real vector index (FAISS, Milvus, etc.) while
+  keeping the same notification contract.
+
+## License
+
+This folder inherits the repository’s license (see the root `LICENSE`).

--- a/inference-notify-demo/README.md
+++ b/inference-notify-demo/README.md
@@ -80,3 +80,134 @@ Example:
 ```
 https://raw.githubusercontent.com/gegedenice/LLM-notify/a1b2c3d4/inference-notify-demo/inbox_server.py
 ```
+
+## Relation to the paper
+
+This demo is a working illustration of the ideas in
+[Distributed AI over Normalized Notifications (LDN)](https://vixra.org/pdf/2510.0040v1.pdf):
+
+- **Create** messages carry a complete, explicit job description (all inference
+  parameters are embedded in the notification’s `object`).
+- **Announce** messages are emitted when the job finishes, pointing to the
+  resulting artifact in `state/` and providing provenance (via PROV).
+
+## Prerequisites
+
+- Python 3.11+
+- [`uv`](https://docs.astral.sh/uv/) installed
+- Provider API key in environment (one of):
+  - **OpenAI**: `OPENAI_API_KEY` or `LLM_API_KEY`
+  - **Groq**: `GROQ_API_KEY` or `LLM_API_KEY`
+  - **HuggingFace**: `HF_API_KEY`/`HUGGINGFACE_API_KEY` or `LLM_API_KEY`
+
+## End‑to‑end flow
+
+1) A `Create` LDN notification with `instrument.action = infer` is posted to the
+   inbox. The `object` holds all CLI parameters that will be passed through to
+   `inference.py` (keys with underscores become `--kebab-case` flags).
+2) The orchestrator polls `/inbox`, builds a command from the `object` fields,
+   and remote-runs the universal client `inference.py`.
+3) The raw text result is stored under `state/inference-result-*.txt` and an
+   `Announce` message is posted back to the inbox with provenance.
+
+## Direct CLI usage of `inference.py`
+
+You can call the client directly (bypassing notifications):
+
+```bash
+uv run inference-notify-demo/inference.py \
+  --provider groq --model llama3-8b-8192 \
+  -u "Explain the W3C Linked Data Notifications standard in 3 sentences." \
+  --temperature 0.1 --max-tokens 300
+```
+
+List models (provider-dependent):
+
+```bash
+uv run inference-notify-demo/inference.py --provider groq --list-models
+```
+
+JSON output and reasoning effort:
+
+```bash
+uv run inference-notify-demo/inference.py \
+  --provider openai --model o3-mini \
+  -u "Summarize OAIS in 2 lines" \
+  --reasoning-effort medium --json-output
+```
+
+Environment variables are detected automatically if `--api-key` is not set.
+
+## `send_ldn.py` argument mapping
+
+`send_ldn.py` mirrors the flags of `inference.py` and places them into the
+notification `object`. For example:
+
+```bash
+uv run inference-notify-demo/send_ldn.py \
+  --inbox http://localhost:8080/inbox \
+  --provider groq --model llama3-8b-8192 \
+  -u "explain reranking in RAG" \
+  --system-prompt "You are an expert in IR" \
+  --temperature 0.1 --max-tokens 500 --json-output
+```
+
+The orchestrator converts underscores to dashes when building flags, so
+`user_prompt` becomes `--user-prompt`, `reasoning_effort` becomes
+`--reasoning-effort`, etc.
+
+## Message schema
+
+Minimal `Create` message used by this demo:
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Create",
+  "actor": "https://example.org/users/cli-user",
+  "object": {
+    "provider": "groq",
+    "model": "llama3-8b-8192",
+    "user_prompt": "Explain the W3C LDN standard in 3 sentences.",
+    "temperature": 0.1,
+    "max_tokens": 300
+  },
+  "instrument": {"type": "Service", "action": "infer"}
+}
+```
+
+`Announce` messages posted by the orchestrator point to
+`http://localhost:8080/state/inference-result-*.txt` and include
+`prov:wasGeneratedBy` for auditability.
+
+## State directory
+
+```
+state/
+  inbox/                         # stored LDN messages
+  seen.txt                       # processed message ids
+  inference-result-<uuid>.txt    # last run output
+```
+
+## Troubleshooting
+
+- If you see `ERROR: No API key provided`, set the appropriate env var (see
+  Prerequisites) or pass `--api-key`.
+- If remote execution fails, pin the script URLs to a specific commit SHA.
+- Unicode issues are handled, but if you see mangled output, ensure your shell
+  locale is UTF‑8.
+
+## Reproducibility and version pinning
+
+For production, replace `main` in any remote script URLs with a commit SHA.
+This prevents accidental upgrades and ensures runs are repeatable.
+
+## Extending
+
+- Add providers by implementing a new loader in `inference.py`.
+- Pass extra OpenAI-compatible options with `--options-json '{...}'`.
+- Adjust logging with `--verbose` and structured results with `--json-output`.
+
+## License
+
+This folder inherits the repository’s license (see the root `LICENSE`).


### PR DESCRIPTION
Add comprehensive documentation to `RAG-notify-demo` and `inference-notify-demo` folders to explain their functionality and relation to the paper.

---
<a href="https://cursor.com/background-agent?bcId=bc-92bd5d9f-5f27-40e0-a5b5-79f425a1b4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92bd5d9f-5f27-40e0-a5b5-79f425a1b4ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

